### PR TITLE
コマンドライン引数のパースをCommandLineParser (NugetPackage) で行えるようにしました

### DIFF
--- a/TestBms2csv/TestBms2csv.csproj
+++ b/TestBms2csv/TestBms2csv.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/TestBms2csv/TestBms2csv.csproj
+++ b/TestBms2csv/TestBms2csv.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="CommandLineParser" Version="2.9.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+        <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+        <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\bms2csv\bms2csv.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/TestBms2csv/UnitTestParseCommandLineArgs.cs
+++ b/TestBms2csv/UnitTestParseCommandLineArgs.cs
@@ -1,0 +1,112 @@
+using bms2csv.Model;
+using CommandLine;
+
+namespace TestBms2csv;
+
+public class Tests
+{
+    [SetUp]
+    public void Setup()
+    {
+    }
+
+    [Test]
+    public void TestConverterMode()
+    {
+        var args = new[] { "bms_path", "output_path" };
+        var cmdOpt = ParseArgs(args);
+
+        Assert.That(cmdOpt.IsViewerMode, Is.EqualTo(false));
+        var opt = new ConverterModeValueOption(cmdOpt.ValueOptions);
+        Assert.Multiple(() =>
+        {
+            Assert.That(opt.InputPath, Is.EqualTo("bms_path"));
+            Assert.That(opt.OutputPath, Is.EqualTo("output_path"));
+        });
+    }
+
+    [Test]
+    public void TestViewerPlayback()
+    {
+        var args = new[] { "-V", "-P", "-N", "123", "filePath", "exeName" };
+        var cmdOpt = ParseArgs(args);
+        Assert.Multiple(() =>
+        {
+            Assert.That(cmdOpt.IsViewerMode, Is.EqualTo(true));
+            Assert.That(cmdOpt.PlayBack, Is.EqualTo(true));
+            Assert.That(cmdOpt.Loop, Is.EqualTo(false));
+            Assert.That(cmdOpt.Shutdown, Is.EqualTo(false));
+            Assert.That(cmdOpt.Measure, Is.EqualTo(123));
+        });
+        var opt = new ViewerModeValueOption(cmdOpt.ValueOptions);
+        Assert.Multiple(() =>
+        {
+            Assert.That(opt.FileName, Is.EqualTo("filePath"));
+            Assert.That(opt.ExeName, Is.EqualTo("exeName"));
+        });
+    }
+
+    [Test]
+    public void TestViewerPlaybackWithoutMeasure()
+    {
+        var args = new[] { "-V", "-P", "filePath", "exeName" };
+        var cmdOpt = ParseArgs(args);
+        Assert.Multiple(() =>
+        {
+            Assert.That(cmdOpt.IsViewerMode, Is.EqualTo(true));
+            Assert.That(cmdOpt.PlayBack, Is.EqualTo(true));
+            Assert.That(cmdOpt.Loop, Is.EqualTo(false));
+            Assert.That(cmdOpt.Shutdown, Is.EqualTo(false));
+            Assert.That(cmdOpt.Measure, Is.EqualTo(0));
+        });
+        var opt = new ViewerModeValueOption(cmdOpt.ValueOptions);
+        Assert.Multiple(() =>
+        {
+            Assert.That(opt.FileName, Is.EqualTo("filePath"));
+            Assert.That(opt.ExeName, Is.EqualTo("exeName"));
+        });
+    }
+
+    [Test]
+    public void TestViewerLoop()
+    {
+        var args = new[] { "-V", "-R", "-N", "123", "filePath", "exeName" };
+        var cmdOpt = ParseArgs(args);
+        Assert.Multiple(() =>
+        {
+            Assert.That(cmdOpt.IsViewerMode, Is.EqualTo(true));
+            Assert.That(cmdOpt.PlayBack, Is.EqualTo(false));
+            Assert.That(cmdOpt.Loop, Is.EqualTo(true));
+            Assert.That(cmdOpt.Shutdown, Is.EqualTo(false));
+            Assert.That(cmdOpt.Measure, Is.EqualTo(123));
+        });
+        var opt = new ViewerModeValueOption(cmdOpt.ValueOptions);
+        Assert.Multiple(() =>
+        {
+            Assert.That(opt.FileName, Is.EqualTo("filePath"));
+            Assert.That(opt.ExeName, Is.EqualTo("exeName"));
+        });
+    }
+
+    [Test]
+    public void TestViewerShutdown()
+    {
+        var args = new[] { "-V", "-S" };
+        var cmdOpt = ParseArgs(args);
+        Assert.Multiple(() =>
+        {
+            Assert.That(cmdOpt.IsViewerMode, Is.EqualTo(true));
+            Assert.That(cmdOpt.PlayBack, Is.EqualTo(false));
+            Assert.That(cmdOpt.Loop, Is.EqualTo(false));
+            Assert.That(cmdOpt.Shutdown, Is.EqualTo(true));
+        });
+    }
+
+    private static CommandLineOption ParseArgs(IEnumerable<string> args)
+    {
+        var result = Parser.Default.ParseArguments<CommandLineOption>(args);
+        if (result.Tag == ParserResultType.NotParsed) Assert.Fail("コマンドライン引数のパースに失敗");
+
+        return result.Value;
+    }
+}

--- a/TestBms2csv/Usings.cs
+++ b/TestBms2csv/Usings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/bms2csv.sln
+++ b/bms2csv.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.30804.86
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "bms2csv", "bms2csv\bms2csv.csproj", "{D31E2B50-7684-4C9D-A183-BF68E792B022}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestBms2csv", "TestBms2csv\TestBms2csv.csproj", "{A9F165F7-D678-4EFB-9319-B8B8DCF8F44E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{D31E2B50-7684-4C9D-A183-BF68E792B022}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D31E2B50-7684-4C9D-A183-BF68E792B022}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D31E2B50-7684-4C9D-A183-BF68E792B022}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A9F165F7-D678-4EFB-9319-B8B8DCF8F44E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9F165F7-D678-4EFB-9319-B8B8DCF8F44E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9F165F7-D678-4EFB-9319-B8B8DCF8F44E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9F165F7-D678-4EFB-9319-B8B8DCF8F44E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/bms2csv/Model/CommandLineOption.cs
+++ b/bms2csv/Model/CommandLineOption.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using CommandLine;
+
+namespace bms2csv.Model;
+
+public class CommandLineOption
+{
+    private const string ViewerVerbSetName = "ViewerVerb";
+    
+    [Option('V', Default = false, HelpText = "ビューアモードとして起動")]
+    public bool IsViewerMode { get; set; }
+    
+    [Option('P', SetName = ViewerVerbSetName, HelpText = "通常再生（ビューアモード用）")]
+    public bool PlayBack { get; set; }
+    
+    [Option('R', SetName = ViewerVerbSetName, HelpText = "ループ再生（ビューアモード用）")]
+    public bool Loop { get; set; }
+    
+    [Option('S', SetName = ViewerVerbSetName, HelpText = "何もせず終了（ビューアモード用）")]
+    public bool Shutdown { get; set; }
+    
+    [Option('N', Default = 0, HelpText = "開始小節（ビューアモード用）")]
+    public int Measure { get; set; }
+    
+    // ハイフンなしの指定オプション
+    [Value(0)]
+    public IEnumerable<string> ValueOptions { get; set; }
+}

--- a/bms2csv/Model/ConverterModeValueOption.cs
+++ b/bms2csv/Model/ConverterModeValueOption.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace bms2csv.Model;
+
+public class ConverterModeValueOption
+{
+    public string InputPath { get; private set; }
+    public string OutputPath { get; private set; }
+
+    public ConverterModeValueOption(IEnumerable<string> valueOptions)
+    {
+        var listOptions = valueOptions.ToList();
+
+        if (listOptions.Count < 2)
+        {
+            throw new ArgumentException("コンストラクタに渡された要素数が2以下です");
+        }
+
+        this.InputPath = listOptions[0];
+        this.OutputPath = listOptions[1];
+    }
+}

--- a/bms2csv/Model/ViewerModeValueOption.cs
+++ b/bms2csv/Model/ViewerModeValueOption.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace bms2csv.Model;
+
+public class ViewerModeValueOption
+{
+    public string FileName { get; private set; }
+    public string ExeName { get; private set; }
+
+    public ViewerModeValueOption(IEnumerable<string> valueOptions)
+    {
+        var listOptions = valueOptions.ToList();
+
+        this.FileName = listOptions[0];
+        this.ExeName = listOptions[1] ?? "Miyabi.exe";
+    }
+}

--- a/bms2csv/Properties/launchSettings.json
+++ b/bms2csv/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "bms2csv": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "commandLineArgs": "test1 test2"
     }
   }
 }

--- a/bms2csv/bms2csv.csproj
+++ b/bms2csv/bms2csv.csproj
@@ -24,6 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
 

--- a/bms2csv/obj/project.assets.json
+++ b/bms2csv/obj/project.assets.json
@@ -2,6 +2,19 @@
   "version": 3,
   "targets": {
     "net6.0": {
+      "CommandLineParser/2.9.1": {
+        "type": "package",
+        "compile": {
+          "lib/netstandard2.0/CommandLine.dll": {
+            "related": ".xml"
+          }
+        },
+        "runtime": {
+          "lib/netstandard2.0/CommandLine.dll": {
+            "related": ".xml"
+          }
+        }
+      },
       "Microsoft.NETCore.Platforms/5.0.0": {
         "type": "package",
         "compile": {
@@ -17,10 +30,14 @@
           "Microsoft.NETCore.Platforms": "5.0.0"
         },
         "compile": {
-          "lib/netstandard2.0/System.Text.Encoding.CodePages.dll": {}
+          "lib/netstandard2.0/System.Text.Encoding.CodePages.dll": {
+            "related": ".xml"
+          }
         },
         "runtime": {
-          "lib/netstandard2.0/System.Text.Encoding.CodePages.dll": {}
+          "lib/netstandard2.0/System.Text.Encoding.CodePages.dll": {
+            "related": ".xml"
+          }
         },
         "runtimeTargets": {
           "runtimes/win/lib/netcoreapp2.0/System.Text.Encoding.CodePages.dll": {
@@ -32,6 +49,28 @@
     }
   },
   "libraries": {
+    "CommandLineParser/2.9.1": {
+      "sha512": "OE0sl1/sQ37bjVsPKKtwQlWDgqaxWgtme3xZz7JssWUzg5JpMIyHgCTY9MVMxOg48fJ1AgGT3tgdH5m/kQ5xhA==",
+      "type": "package",
+      "path": "commandlineparser/2.9.1",
+      "files": [
+        ".nupkg.metadata",
+        ".signature.p7s",
+        "CommandLine20.png",
+        "License.md",
+        "README.md",
+        "commandlineparser.2.9.1.nupkg.sha512",
+        "commandlineparser.nuspec",
+        "lib/net40/CommandLine.dll",
+        "lib/net40/CommandLine.xml",
+        "lib/net45/CommandLine.dll",
+        "lib/net45/CommandLine.xml",
+        "lib/net461/CommandLine.dll",
+        "lib/net461/CommandLine.xml",
+        "lib/netstandard2.0/CommandLine.dll",
+        "lib/netstandard2.0/CommandLine.xml"
+      ]
+    },
     "Microsoft.NETCore.Platforms/5.0.0": {
       "sha512": "VyPlqzH2wavqquTcYpkIIAQ6WdenuKoFN0BdYBbCWsclXacSOHNQn66Gt4z5NBqEYW0FAPm5rlvki9ZiCij5xQ==",
       "type": "package",
@@ -94,6 +133,7 @@
   },
   "projectFileDependencyGroups": {
     "net6.0": [
+      "CommandLineParser >= 2.9.1",
       "System.Text.Encoding.CodePages >= 5.0.0"
     ]
   },
@@ -134,6 +174,10 @@
       "net6.0": {
         "targetAlias": "net6.0",
         "dependencies": {
+          "CommandLineParser": {
+            "target": "Package",
+            "version": "[2.9.1, )"
+          },
           "System.Text.Encoding.CodePages": {
             "target": "Package",
             "version": "[5.0.0, )"
@@ -150,12 +194,26 @@
         ],
         "assetTargetFallback": true,
         "warn": true,
+        "downloadDependencies": [
+          {
+            "name": "Microsoft.AspNetCore.App.Ref",
+            "version": "[6.0.12, 6.0.12]"
+          },
+          {
+            "name": "Microsoft.NETCore.App.Host.osx-arm64",
+            "version": "[6.0.12, 6.0.12]"
+          },
+          {
+            "name": "Microsoft.NETCore.App.Ref",
+            "version": "[6.0.12, 6.0.12]"
+          }
+        ],
         "frameworkReferences": {
           "Microsoft.NETCore.App": {
             "privateAssets": "all"
           }
         },
-        "runtimeIdentifierGraphPath": "/usr/local/share/dotnet/sdk/6.0.400/RuntimeIdentifierGraph.json"
+        "runtimeIdentifierGraphPath": "/usr/local/share/dotnet/sdk/7.0.101/RuntimeIdentifierGraph.json"
       }
     }
   }


### PR DESCRIPTION
コマンドライン引数を一個一個文字列を見ながらパースしていたので、コマンドライン引数用の解析パッケージを使って解析できるようにしました。
* これを導入することで、一つ一つ文字列を解析するのに比べて新たな不具合が起こりにくくなるのと、新規で拡張が行いやすくなります。
* 広く使われているパッケージであるため安全性は比較的高いと思われます
* ユニットテストを追加したので仕様通り動作していることは保証しています